### PR TITLE
Add summary and deep link keys for tv shows and movies

### DIFF
--- a/custom_components/kodi_recently_added/config_flow.py
+++ b/custom_components/kodi_recently_added/config_flow.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Dict, Optional
 
-import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.kodi.const import DOMAIN as KODI_DOMAIN
 from homeassistant.core import callback
+import voluptuous as vol
 
 from .const import CONF_HIDE_WATCHED, CONF_KODI_INSTANCE, DOMAIN
 
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 OPTIONS_SCHEMA = vol.Schema({vol.Optional(CONF_HIDE_WATCHED, default=False): bool})
 
 
-class KodiRecentlyAddedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class KodiRecentlyAddedConfifFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Kodi Recently Added config flow."""
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]]):

--- a/custom_components/kodi_recently_added/config_flow.py
+++ b/custom_components/kodi_recently_added/config_flow.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Dict, Optional
 
+import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.kodi.const import DOMAIN as KODI_DOMAIN
 from homeassistant.core import callback
-import voluptuous as vol
 
 from .const import CONF_HIDE_WATCHED, CONF_KODI_INSTANCE, DOMAIN
 
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 OPTIONS_SCHEMA = vol.Schema({vol.Optional(CONF_HIDE_WATCHED, default=False): bool})
 
 
-class KodiRecentlyAddedConfifFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class KodiRecentlyAddedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Kodi Recently Added config flow."""
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]]):

--- a/custom_components/kodi_recently_added/manifest.json
+++ b/custom_components/kodi_recently_added/manifest.json
@@ -8,5 +8,5 @@
   "domain": "kodi_recently_added",
   "name": "Kodi Recently Added Media",
   "requirements": [],
-  "version": "2.0.7"
+  "version": "2.1.0"
 }

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,4 +1,5 @@
 """Tests for entities.py."""
+
 from unittest import mock
 
 import pykodi
@@ -17,7 +18,7 @@ def test_kodi_media_entity_init_base_web_url_https():
     }
     entity = KodiMediaEntity(mock.Mock(), config)
     expected = "https://username:password@127.0.0.1:8080/image/image%3A%2F%2F"
-    assert expected == entity.base_web_url
+    assert expected == entity.base_web_image_url
 
 
 def test_kodi_media_entity_init_base_web_url_http():
@@ -31,7 +32,7 @@ def test_kodi_media_entity_init_base_web_url_http():
     }
     entity = KodiMediaEntity(mock.Mock(), config)
     expected = "http://username:password@127.0.0.1:8080/image/image%3A%2F%2F"
-    assert expected == entity.base_web_url
+    assert expected == entity.base_web_image_url
 
 
 def test_kodi_media_entity_init_base_web_url_no_auth():
@@ -45,7 +46,7 @@ def test_kodi_media_entity_init_base_web_url_no_auth():
     }
     entity = KodiMediaEntity(mock.Mock(), config)
     expected = "http://127.0.0.1:8080/image/image%3A%2F%2F"
-    assert expected == entity.base_web_url
+    assert expected == entity.base_web_image_url
 
 
 def test_get_web_url_http_already():


### PR DESCRIPTION
Addresses feature request in #20 .

Adds the following:
* summary - The plot details of the movie or episode
* deep_link - A URL link to your kodi instance (if the web interface is enabled). This allows linking directly to a movie or tv show in the [upcoming media card](https://github.com/custom-cards/upcoming-media-card).